### PR TITLE
Fix NullPointerException in OwnerController.details() method

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -253,6 +253,10 @@ class OwnerController implements InitializingBean {
 
 		Owner owner = this.owners.findById(ownerId);
 
+		if (owner == null) {
+			throw new RuntimeException("Owner not found with id: " + ownerId);
+		}
+
 		return owner.toString();
 
 	}


### PR DESCRIPTION
## Problem
The `OwnerController.details()` method was throwing a `NullPointerException` when trying to access non-existent owner IDs (e.g., ID 16). The issue occurred because the method called `owner.toString()` on a null object returned by `owners.findById(ownerId)`.

## Solution
Added null validation after the `OwnerRepository.findById()` call. If the owner is null, the method now throws a `RuntimeException` with a descriptive error message: "Owner not found with id: {ownerId}".

## Changes Made
- Added null check in `details()` method at line 256
- Throws `RuntimeException` with clear error message for non-existent owners
- Minimal change focused only on the root cause

## Testing
This fix addresses the specific case where owner ID 16 (non-existent) was causing the NullPointerException.

**Fixes Error ID:** dc31b20a-711d-11f0-9fdd-c23e5f45c404  
**Affected Endpoint:** `/owners/{ownerId}/details`  
**Service:** spring-petclinic